### PR TITLE
Post path helpers

### DIFF
--- a/web/controllers/post_controller.ex
+++ b/web/controllers/post_controller.ex
@@ -40,7 +40,7 @@ defmodule Churchspace.PostController do
       {:ok, _post} ->
         conn
         |> put_flash(:info, "Post created successfully.")
-        |> redirect(to: post_path(conn, :index))
+        |> redirect(to: path_for_post(conn, :index))
       {:error, changeset} ->
         render(conn, "new.html", changeset: changeset)
     end
@@ -65,7 +65,7 @@ defmodule Churchspace.PostController do
       {:ok, post} ->
         conn
         |> put_flash(:info, "Post updated successfully.")
-        |> redirect(to: post_path(conn, :show, post))
+        |> redirect(to: path_for_post(conn, :show, post))
       {:error, changeset} ->
         render(conn, "edit.html", post: post, changeset: changeset)
     end
@@ -80,6 +80,6 @@ defmodule Churchspace.PostController do
 
     conn
     |> put_flash(:info, "Post deleted successfully.")
-    |> redirect(to: post_path(conn, :index))
+    |> redirect(to: path_for_post(conn, :index))
   end
 end

--- a/web/path_helpers.ex
+++ b/web/path_helpers.ex
@@ -1,0 +1,12 @@
+defmodule Churchspace.PathHelpers do
+  import Churchspace.Router.Helpers
+
+  def path_for_post(conn, route, params \\ []) when is_atom(route) do
+    case conn.assigns do
+      %{event: event = %Churchspace.Event{}} ->
+        event_post_path(conn, route, event, params)
+      _ ->
+        post_path(conn, route, params)
+    end
+  end
+end

--- a/web/path_helpers.ex
+++ b/web/path_helpers.ex
@@ -9,4 +9,13 @@ defmodule Churchspace.PathHelpers do
         post_path(conn, route, params)
     end
   end
+
+  def url_for_post(conn, route, params \\ []) when is_atom(route) do
+    case conn.assigns do
+      %{event: event = %Churchspace.Event{}} ->
+        event_post_url(conn, route, event, params)
+      _ ->
+        post_url(conn, route, params)
+    end
+  end
 end

--- a/web/templates/post/edit.html.eex
+++ b/web/templates/post/edit.html.eex
@@ -1,6 +1,6 @@
 <h2>Edit post</h2>
 
 <%= render "form.html", changeset: @changeset,
-                        action: post_path(@conn, :update, @post) %>
+                        action: path_for_post(@conn, :update, @post) %>
 
-<%= link "Back", to: post_path(@conn, :index) %>
+<%= link "Back", to: path_for_post(@conn, :index) %>

--- a/web/templates/post/index.html.eex
+++ b/web/templates/post/index.html.eex
@@ -16,13 +16,13 @@
       <td><%= post.body %></td>
 
       <td class="text-right">
-        <%= link "Show", to: post_path(@conn, :show, post), class: "btn btn-default btn-xs" %>
-        <%= link "Edit", to: post_path(@conn, :edit, post), class: "btn btn-default btn-xs" %>
-        <%= link "Delete", to: post_path(@conn, :delete, post), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+        <%= link "Show", to: path_for_post(@conn, :show, post), class: "btn btn-default btn-xs" %>
+        <%= link "Edit", to: path_for_post(@conn, :edit, post), class: "btn btn-default btn-xs" %>
+        <%= link "Delete", to: path_for_post(@conn, :delete, post), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
       </td>
     </tr>
 <% end %>
   </tbody>
 </table>
 
-<%= link "New post", to: post_path(@conn, :new) %>
+<%= link "New post", to: path_for_post(@conn, :new) %>

--- a/web/templates/post/new.html.eex
+++ b/web/templates/post/new.html.eex
@@ -1,9 +1,6 @@
 <h2>New post</h2>
 
 <%= render "form.html", changeset: @changeset,
-                        action: if @event, do:
-                                  event_post_path(@conn, :create, @event),
-                                else:
-                                  post_path(@conn, :create) %>
+                        action: path_for_post(@conn, :create) %>
 
-<%= link "Back", to: post_path(@conn, :index) %>
+<%= link "Back", to: path_for_post(@conn, :index) %>

--- a/web/templates/post/show.html.eex
+++ b/web/templates/post/show.html.eex
@@ -14,5 +14,5 @@
 
 </ul>
 
-<%= link "Edit", to: post_path(@conn, :edit, @post) %>
-<%= link "Back", to: post_path(@conn, :index) %>
+<%= link "Edit", to: path_for_post(@conn, :edit, @post) %>
+<%= link "Back", to: path_for_post(@conn, :index) %>

--- a/web/web.ex
+++ b/web/web.ex
@@ -36,6 +36,8 @@ defmodule Churchspace.Web do
 
       import Churchspace.Router.Helpers
       import Churchspace.Gettext
+
+      import Churchspace.PathHelpers
     end
   end
 
@@ -52,6 +54,8 @@ defmodule Churchspace.Web do
       import Churchspace.Router.Helpers
       import Churchspace.ErrorHelpers
       import Churchspace.Gettext
+
+      import Churchspace.PathHelpers
     end
   end
 


### PR DESCRIPTION
Load correct path for post or event posts depending on if `event` is assigned
